### PR TITLE
Update README.md to reference Legacy Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Update Connected App
 
 New Named Credential 0. Wait for 10 minutes for the Connected App information to flow to servers, before taking the next steps
 
-1. Go to Setup > Security > Named Credentials.
+1. Go to Setup > Security > Named Credentials
 
-2. Click New Named Credential
+2. Click 'New Legacy' in the dropdown next to 'New'
 
 3. Enter Label and Name as 'DataClass_NC'
 


### PR DESCRIPTION
Named Credentials received an upgrade in Winter '23, with the old version being relabeled 'Legacy' in the Salesforce Setup UI. Since our use case for a named credential is same-org auth and not multi-org for now, at present, it makes little sense to upgrade to the new version.

Adjusts README.md to describe how to access the now-buried 'New Legacy' button.